### PR TITLE
Trigger checks every week

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,10 +18,8 @@ jobs:
       - name: Get scarb version
         id: extractScarbVersion
         run: |
-          curl -s https://api.github.com/repos/foundry-rs/starknet-foundry/releases/latest | grep tarball_url | cut -d '"' -f 4 | xargs -n 1 curl -L -o latest.tar.gz
-          mkdir latest
-          tar -xz --strip-components=1 -C latest -f latest.tar.gz
-          version=$(grep scarb latest/.tool-versions | awk '{print $2}')
+          snfoundry_version=$(curl -s https://api.github.com/repos/foundry-rs/starknet-foundry/releases/latest | grep tarball_url | awk -F '/' '{print $8}' | tr -d '",')
+          version=$(curl -s https://raw.githubusercontent.com/foundry-rs/starknet-foundry/$snfoundry_version/.tool-versions | awk '{print $2}')
           
           echo "scarbVersion=$version" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,6 +19,6 @@ jobs:
           scarb-version: 2.3.0
       - uses: foundry-rs/setup-snfoundry@v2
         with:
-          starknet-foundry-version: 0.9.1
+          starknet-foundry-version: latest
 
       - run: snforge test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,9 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Get scarb version
+        id: extractScarbVersion
+        run: |
+          curl -s https://api.github.com/repos/foundry-rs/starknet-foundry/releases/latest | grep tarball_url | cut -d '"' -f 4 | xargs -n 1 curl -L -o latest.tar.gz
+          mkdir latest
+          tar -xz --strip-components=1 -C latest -f latest.tar.gz
+          version=$(grep scarb latest/.tool-versions | awk '{print $2}')
+          
+          echo "scarbVersion=$version" >> "$GITHUB_OUTPUT"
+
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: 2.3.0
+          scarb-version: ${{ steps.extractScarbVersion.outputs.scarbVersion }}
       - uses: foundry-rs/setup-snfoundry@v2
         with:
           starknet-foundry-version: latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    # At 16:00 on Wednesday
+    - cron: "0 16 * * 3"
 
 jobs:
   run-tests:

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -10,7 +10,7 @@ casm = true
 
 [dependencies]
 starknet = "2.3.0"
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.5.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.10.1" }
 
 [tool.snforge]
 # exit_first = true


### PR DESCRIPTION
Closes https://github.com/foundry-rs/starknet-foundry/issues/965

Add schedule trigger to checks so they are run every week. This way we don't have to manually test this action for new releases since the checks will eventually run.